### PR TITLE
Enables downloading all issues into single table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ specification/
 collection/
 pipeline/
 dataset/
+issues/
 
 # ignore databases
 *.db

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ first-pass::
 	bin/download-collection.sh
 	bin/download-pipeline.sh
 	bin/concat.sh
-	#bin/download-issues.sh
+	bin/download-issues.sh
 	#bin/download-resources.sh
-	#python3 bin/concat-issues.py
+	python3 bin/concat-issues.py
 
 second-pass::	$(DB)
 

--- a/bin/concat-issues.py
+++ b/bin/concat-issues.py
@@ -4,10 +4,14 @@ import sys
 import csv
 import glob
 import re
+import os
 
-fields = ["resource", "pipeline", "row-number", "field", "issue-type", "value"]
+fields = ["resource", "pipeline", "row-number", "field", "issue-type", "value", "message", "dataset", "entry-number", "line-number"]
 
-w = csv.DictWriter(open("dataset/issue.csv", "w"), fields)
+issues_dir = "issues/"
+os.makedirs(issues_dir, exist_ok=True)
+
+w = csv.DictWriter(open(issues_dir + "issue.csv", "w"), fields)
 w.writeheader()
 
 for path in glob.glob("var/issue/*/*.csv"):

--- a/bin/load.py
+++ b/bin/load.py
@@ -49,10 +49,14 @@ tables = {
     "transform": "pipeline",
     "filter": "pipeline",
     "lookup": "pipeline",
+
+    "issue": "issues",
 }
 
 indexes = {
     "source": ["endpoint"],
+    "issue": ["resource", "field", "issue-type"],
+    "issue-type": ["severity"],
     "log": ["endpoint", "resource"],
     "resource_dataset": ["resource", "dataset"],
     "resource_endpoint": ["resource", "endpoint"],

--- a/bin/resources.py
+++ b/bin/resources.py
@@ -8,14 +8,14 @@ resources = {}
 pipelines = {}
 
 # TBD: replace with a single SQL query on a collection database ..
-for row in csv.DictReader(open("dataset/endpoint.csv", newline="")):
+for row in csv.DictReader(open("collection/endpoint.csv", newline="")):
     endpoint = row["endpoint"]
     endpoints[endpoint] = row
     endpoints[endpoint].setdefault("pipelines", {})
     endpoints[endpoint].setdefault("collection", "")
 
 # load sources
-for row in csv.DictReader(open("dataset/source.csv", newline="")):
+for row in csv.DictReader(open("collection/source.csv", newline="")):
     endpoint = row["endpoint"]
 
     if endpoint:
@@ -28,7 +28,7 @@ for row in csv.DictReader(open("dataset/source.csv", newline="")):
                 endpoints[endpoint]["collection"] = row["collection"]
 
 # load resources
-for row in csv.DictReader(open("dataset/resource.csv", newline="")):
+for row in csv.DictReader(open("collection/resource.csv", newline="")):
     resource = row["resource"]
     resources[resource] = row
     resources[resource].setdefault("pipelines", {})


### PR DESCRIPTION
This PR re-enables the construction of an 'issue' table containing issues for all datasets. https://trello.com/c/YsZpfpKN/1028-create-collective-issue-table-in-digital-land-database

Most of this code already existed but wasn't being used. First the issues are downloaded from S3 buckets using the download-issues.sh command. Then all the issues are put into a single .csv using concat-issues.py. Finally, a table is made in digital-land from this .csv in load.py.

The reason for doing this is so that summaries of all the issues can be obtained in one query for use in reporting work