### PR TITLE
Adds column-field table to digital land builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ pipeline/
 dataset/
 issues/
 expectations/
+column-field/
 
 # ignore databases
 *.db

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,11 @@ first-pass::
 	bin/download-pipeline.sh
 	bin/concat.sh
 	bin/download-issues.sh
+	bin/download-column-field.sh
 	bin/download-expectations.sh
 	#bin/download-resources.sh
 	python3 bin/concat-issues.py
+	python3 bin/concat-column-field.py
 
 
 second-pass::	$(DB)

--- a/bin/concat-column-field.py
+++ b/bin/concat-column-field.py
@@ -19,9 +19,7 @@ for path in glob.glob("var/column-field/*/*.csv"):
     m = re.search(r"/([a-zA-Z0-9_-]+)/([a-f0-9]+).csv$", path)
     pipeline = m.group(1)
     resource = m.group(2)
-    print(pipeline, resource)
     for row in csv.DictReader(open(path, newline="")):
         row["resource"] = resource
         row["dataset"] = pipeline
-        print(row)
         w.writerow(row)

--- a/bin/concat-column-field.py
+++ b/bin/concat-column-field.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import sys
+import csv
+import glob
+import re
+import os
+
+fields = ["dataset", "resource", "column", "field",  "entry-date", "end-date", "start-date"]
+
+column_field_dir = "column-field/"
+os.makedirs(column_field_dir, exist_ok=True)
+
+w = csv.DictWriter(open(column_field_dir + "column-field.csv", "w"), fields)
+w.writeheader()
+
+for path in glob.glob("var/column-field/*/*.csv"):
+
+    m = re.search(r"/([a-zA-Z0-9_-]+)/([a-f0-9]+).csv$", path)
+    pipeline = m.group(1)
+    resource = m.group(2)
+    print(pipeline, resource)
+    for row in csv.DictReader(open(path, newline="")):
+        row["resource"] = resource
+        row["dataset"] = pipeline
+        print(row)
+        w.writerow(row)

--- a/bin/download-column-field.sh
+++ b/bin/download-column-field.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+s3="https://files.planning.data.gov.uk/"
+column_field_dir="column-field/"
+
+python3 bin/resources.py |
+while read collection pipeline resource
+do
+    dir=var/column-field/$pipeline
+    path=$dir/$resource.csv
+
+    echo collection: $collection pipeline: $pipeline resource: $resource
+
+    if [ ! -f $path ] ; then
+        mkdir -p $dir
+        set -x
+        curl -qsfL $flags "$s3$collection-collection/var/column-field/$pipeline/$resource.csv" > $path
+        set +x
+    fi
+done

--- a/bin/load.py
+++ b/bin/load.py
@@ -59,6 +59,8 @@ tables = {
 
     "issue": "issues",
 
+    "column-field": "column-field",
+
     "expectation-result": "expectations",
     "expectation-issue": "expectations",
 }


### PR DESCRIPTION
Adds a table to the digital land database that contains all the column-field mappings. Will be used as part of the compliance/conformance reporting.
First downloads all the column mappings from s3 buckets, then concatenates them into one .csv, then they are added as a table to digital land