### PR TITLE
Create files for failed resources

### DIFF
--- a/bin/download-expectations.sh
+++ b/bin/download-expectations.sh
@@ -3,56 +3,29 @@
 set -e
 
 s3="https://files.planning.data.gov.uk/"
-aws_s3_bucket="s3://development-collection-data/" 
 expectations_dir="expectations/"
 
 dir=var/$expectations_dir
 mkdir -p $dir
 
-get_headers() {
-    case $1 in
-        endpoint.csv)
-            echo "endpoint,endpoint-url,parameters,plugin,entry-date,start-date,end-date"
-            ;;
-        source.csv)
-            echo "source,attribution,collection,documentation-url,endpoint,licence,organisation,pipelines,entry-date,start-date,end-date"
-            ;;
-        log.csv)
-            echo "bytes,content-type,elapsed,endpoint,resource,status,entry-date,start-date,end-date,exception"
-            ;;
-        resource.csv)
-            echo "resource,bytes,organisations,datasets,endpoints,start-date,end-date"
-            ;;
-        old-resource.csv)
-            echo "old-resource,status,resource"
-            ;;
-        *)
-            echo ""
-            ;;
-    esac
-}
-
-csvcut -c collection specification/collection.csv | tail -n +2 |
-while read collection
+csvcut -c dataset,collection specification/dataset.csv | tr ',' ' ' | tail -n +2 |
+while read dataset collection
 do
-    for file in endpoint.csv source.csv log.csv resource.csv old-resource.csv
-    do
-        dir=var/collection/$collection
-        path=var/collection/$collection/$file
-        if [ ! -f $path ] ; then
-            mkdir -p $dir
-            set -x
-            if ! curl -qsfL --retry 3 -o $path "$s3$collection-collection/collection/$file"; then
-                # If curl fails, create a new file with the appropriate headers
-                headers=$(get_headers $file)
-                echo "$headers" > $path
-                # Upload the newly created file to the S3 bucket
-                aws s3 cp $path $aws_s3_bucket$collection-collection/collection/$file --no-progress
-                echo "File $file created and uploaded to S3: $aws_s3_bucket$collection-collection/collection/$file"
+    if [ -n "$collection" ] ; then
+        echo $dataset $collection
+
+        for file in $dataset-expectation-result.csv $dataset-expectation-issue.csv
+        do
+            path=$dir$file
+            if [ ! -f $path ] ; then
+                set -x
+                if ! curl -qsfL $flags --retry 3 -o $path $s3$collection-collection/dataset/$file; then
+                    echo "*** UNABLE TO DOWNLOAD $collection FROM $path ***"
+                fi
+                set +x
             fi
-            set +x
-        fi
-    done
+        done
+    fi
 done
 
 mkdir -p expectations

--- a/bin/download-expectations.sh
+++ b/bin/download-expectations.sh
@@ -3,27 +3,56 @@
 set -e
 
 s3="https://files.planning.data.gov.uk/"
+aws_s3_bucket="s3://development-collection-data/" 
 expectations_dir="expectations/"
 
 dir=var/$expectations_dir
 mkdir -p $dir
 
-csvcut -c dataset,collection specification/dataset.csv | tr ',' ' ' | tail -n +2 |
-while read dataset collection
-do
-    if [ -n "$collection" ] ; then
-        echo $dataset $collection
+get_headers() {
+    case $1 in
+        endpoint.csv)
+            echo "endpoint,endpoint-url,parameters,plugin,entry-date,start-date,end-date"
+            ;;
+        source.csv)
+            echo "source,attribution,collection,documentation-url,endpoint,licence,organisation,pipelines,entry-date,start-date,end-date"
+            ;;
+        log.csv)
+            echo "bytes,content-type,elapsed,endpoint,resource,status,entry-date,start-date,end-date,exception"
+            ;;
+        resource.csv)
+            echo "resource,bytes,organisations,datasets,endpoints,start-date,end-date"
+            ;;
+        old-resource.csv)
+            echo "old-resource,status,resource"
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
+}
 
-        for file in $dataset-expectation-result.csv $dataset-expectation-issue.csv
-        do
-            path=$dir$file
-            if [ ! -f $path ] ; then
-                set -x
-                curl -qsfL $flags --retry 3 -o $path $s3$collection-collection/dataset/$file || echo "*** UNABLE TO DOWNLOAD $path ***"
-                set +x
+csvcut -c collection specification/collection.csv | tail -n +2 |
+while read collection
+do
+    for file in endpoint.csv source.csv log.csv resource.csv old-resource.csv
+    do
+        dir=var/collection/$collection
+        path=var/collection/$collection/$file
+        if [ ! -f $path ] ; then
+            mkdir -p $dir
+            set -x
+            if ! curl -qsfL --retry 3 -o $path "$s3$collection-collection/collection/$file"; then
+                # If curl fails, create a new file with the appropriate headers
+                headers=$(get_headers $file)
+                echo "$headers" > $path
+                # Upload the newly created file to the S3 bucket
+                aws s3 cp $path $aws_s3_bucket$collection-collection/collection/$file --no-progress
+                echo "File $file created and uploaded to S3: $aws_s3_bucket$collection-collection/collection/$file"
             fi
-        done
-    fi
+            set +x
+        fi
+    done
 done
 
 mkdir -p expectations


### PR DESCRIPTION
Added in a print statement if digital land builder fails for missing files in a particular collection and allows the process to continue without breaking for the rest of the collections