### PR TITLE
Download operational issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dataset/
 issues/
 expectations/
 column-field/
+performance/
 
 # ignore databases
 *.db

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ first-pass::
 	bin/download-pipeline.sh
 	bin/concat.sh
 	bin/download-issues.sh
+	bin/download-operational-issues.sh
 	bin/download-column-field.sh
 	bin/download-expectations.sh
 	#bin/download-resources.sh

--- a/bin/concat-issues.py
+++ b/bin/concat-issues.py
@@ -24,3 +24,12 @@ for path in glob.glob("var/issue/*/*.csv"):
         row["resource"] = resource
         row["pipeline"] = pipeline
         w.writerow(row)
+
+operational_issue_dir = "performance/operational_issue/"
+fields = ["col1", "col2"]
+w = csv.DictWriter(open(os.path.join(operational_issue_dir,"operational-issue.csv"), "w"), fields)
+w.writeheader()
+
+for path in glob.glob("performance/operational_issue/*/operational-issue.csv"):
+    for row in csv.DictReader(open(path, newline="")):
+        w.writerow(row)

--- a/bin/concat-issues.py
+++ b/bin/concat-issues.py
@@ -26,7 +26,7 @@ for path in glob.glob("var/issue/*/*.csv"):
         w.writerow(row)
 
 operational_issue_dir = "performance/operational_issue/"
-fields = ["col1", "col2"]
+fields = ["dataset","resource","line-number","entry-number","field","issue-type","value","message","entry-date"]
 w = csv.DictWriter(open(os.path.join(operational_issue_dir,"operational-issue.csv"), "w"), fields)
 w.writeheader()
 

--- a/bin/download-operational-issues.sh
+++ b/bin/download-operational-issues.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+#set -e
+
+s3="https://files.planning.data.gov.uk/"
+operational_issue_dir="performance/operational_issue"
+
+mkdir -p $operational_issue_dir
+
+csvcut -c dataset specification/dataset.csv | tr ',' ' ' | tail -n +2 |
+while read dataset
+do
+    path=$operational_issue_dir/$dataset/
+    if [ ! -f $path ] ; then
+        mkdir -p $dir
+        set -x
+        echo "$s3$operational_issue_dir/$dataset/operational-issue.csv"
+        echo $path
+        # curl -qsfL $flags "$s3$operational_issue_dir/$dataset/operational-issue.csv" > $path
+        set +x
+    fi
+done

--- a/bin/download-operational-issues.sh
+++ b/bin/download-operational-issues.sh
@@ -3,17 +3,19 @@
 #set -e
 
 s3="https://files.planning.data.gov.uk/"
-operational_issue_dir="performance/operational_issue"
+operational_issue_dir="performance/operational_issue/"
 
 mkdir -p $operational_issue_dir
 
 csvcut -c dataset specification/dataset.csv | tr ',' ' ' | tail -n +2 |
 while read dataset
 do
-    path=$operational_issue_dir/$dataset/
+    dir=$operational_issue_dir$dataset
+    path=$dir/operational-issue.csv
     if [ ! -f $path ] ; then
+        mkdir -p $dir
         set -x
-        # curl -qsfL $flags "$s3$operational_issue_dir/$dataset/operational-issue.csv" > $path
+        curl -qsfL $flags "$s3$operational_issue_dir$dataset/operational-issue.csv" > $path
         set +x
     fi
 done

--- a/bin/download-operational-issues.sh
+++ b/bin/download-operational-issues.sh
@@ -12,10 +12,7 @@ while read dataset
 do
     path=$operational_issue_dir/$dataset/
     if [ ! -f $path ] ; then
-        mkdir -p $dir
         set -x
-        echo "$s3$operational_issue_dir/$dataset/operational-issue.csv"
-        echo $path
         # curl -qsfL $flags "$s3$operational_issue_dir/$dataset/operational-issue.csv" > $path
         set +x
     fi

--- a/bin/load.py
+++ b/bin/load.py
@@ -7,6 +7,8 @@ import sys
 import csv
 import logging
 import sqlite3
+
+import pandas as pd
 from digital_land.package.sqlite import SqlitePackage
 
 
@@ -87,6 +89,10 @@ if __name__ == "__main__":
     package.create()
 
     conn = sqlite3.connect(path)
+
+    operational_issue_log = pd.read_csv("performance/operational_issue/operational-issue.csv")
+    operational_issue_log.to_sql("operational_issue", conn, if_exists="replace", index=False)
+    
     conn.execute("""
     CREATE TABLE reporting_most_recent_log AS
     select t1.*


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds the operational issue log to the digital land database.
First, downloads all the operational issue logs per dataset from the CDN. Then, concatenates them into one file `performance/operational_issue/operational-issue.csv`. The table is then created in load.py

## Related Tickets & Documents

https://trello.com/c/02BkRiMU/3485-load-operational-issues-historically-in-digital-land-db

## [optional] Are there any dependencies on other PRs or Work?

Cannot be merged until the code that handles uploading the per dataset operational issue log to s3 is completed