### PR TITLE
Remove endpoint end date and rename: status/exception -> latest_status/latest_exception

### DIFF
--- a/bin/load_performance.py
+++ b/bin/load_performance.py
@@ -132,7 +132,7 @@ def fetch_endpoint_summary(db_path):
 def create_performance_tables(merged_data, cf_merged_data, endpoint_summary_data, performance_db_path):
     conn = sqlite3.connect(performance_db_path)
     column_field_table_name = "endpoint_dataset_resource_summary"
-    column_field_table_fields = ["organisation", "organisation_name", "cohort", "dataset", "collection", "pipeline", "endpoint", "endpoint_url", "resource", "resource_start_date", "endpoint_end_date",
+    column_field_table_fields = ["organisation", "organisation_name", "cohort", "dataset", "collection", "pipeline", "endpoint", "endpoint_url", "resource", "resource_start_date",
                                   "resource_end_date", "latest_log_entry_date", "mapping_field", "non_mapping_field"]
     cf_merged_data_filtered = cf_merged_data[cf_merged_data['resource'] != ""]
     cf_merged_data_filtered = cf_merged_data_filtered[cf_merged_data_filtered['endpoint'].notna()]
@@ -140,7 +140,7 @@ def create_performance_tables(merged_data, cf_merged_data, endpoint_summary_data
         column_field_table_name, conn, if_exists="replace", index=False)
 
     issue_table_name = "endpoint_dataset_issue_type_summary"
-    issue_table_fields = ["organisation", "organisation_name", "cohort", "dataset", "collection", "pipeline", "endpoint", "endpoint_url","endpoint_end_date", "resource", "resource_start_date", 
+    issue_table_fields = ["organisation", "organisation_name", "cohort", "dataset", "collection", "pipeline", "endpoint", "endpoint_url", "resource", "resource_start_date", 
                           "resource_end_date", "latest_log_entry_date", "count_issues", "date", "issue_type", "severity", "responsibility", "fields"]
     issue_data_filtered = merged_data[merged_data['resource'] != "" ]
     issue_data_filtered = issue_data_filtered[issue_data_filtered['endpoint'].notna() ]
@@ -159,7 +159,7 @@ def create_performance_tables(merged_data, cf_merged_data, endpoint_summary_data
         ),
         error_endpoint_count=pd.NamedAgg(
             column='endpoint',
-            aggfunc=lambda x: x[(merged_data.loc[x.index,'status'] != '200') &
+            aggfunc=lambda x: x[(merged_data.loc[x.index,'latest_status'] != '200') &
                                 (merged_data.loc[x.index,'endpoint_end_date'].notna())].nunique()
         ),
         count_issue_error_internal=pd.NamedAgg(
@@ -229,8 +229,8 @@ def fetch_reporting_data(db_path):
             rhe.endpoint_url,
             rhe.licence,
             rhe.resource,
-            rhe.status,
-            rhe.exception,
+            rhe.latest_status,
+            rhe.latest_exception,
             rhe.endpoint_entry_date,
             rhe.endpoint_end_date,
             rhe.resource_start_date,

--- a/bin/load_reporting_tables.py
+++ b/bin/load_reporting_tables.py
@@ -29,11 +29,11 @@ def fetch_historic_endpoints_data_from_dl(db_path):
         l.exception as latest_exception,
         l.resource,
 
-        max(l.entry_date) as latest_log_entry_date,
-        e.entry_date as endpoint_entry_date,
-        e.end_date as endpoint_end_date,
-        r.start_date as resource_start_date,
-        r.end_date as resource_end_date
+        substring(max(l.entry_date),1,10) as latest_log_entry_date,
+        substring(e.entry_date,1,10) as endpoint_entry_date,
+        substring(e.end_date,1,10) as endpoint_end_date,
+        substring(r.start_date,1,10) as resource_start_date,
+        substring(r.end_date,1,10) as resource_end_date
 
     FROM
         log l
@@ -73,11 +73,11 @@ def fetch_latest_endpoints_data_from_dl(db_path):
                 l.exception as latest_exception,
                 l.resource,
 
-                max(l.entry_date) as latest_log_entry_date,
-                e.entry_date as endpoint_entry_date,
-                e.end_date as endpoint_end_date,
-                r.start_date as resource_start_date,
-                r.end_date as resource_end_date,
+                substring(max(l.entry_date),1,10) as latest_log_entry_date,
+                substring(e.entry_date,1,10) as endpoint_entry_date,
+                substring(e.end_date,1,10) as endpoint_end_date,
+                substring(r.start_date,1,10) as resource_start_date,
+                substring(r.end_date,1,10) as resource_end_date,
             
                 row_number() over (partition by s.organisation,sp.pipeline order by e.entry_date desc, l.entry_date desc) as rn
 

--- a/bin/load_reporting_tables.py
+++ b/bin/load_reporting_tables.py
@@ -25,8 +25,8 @@ def fetch_historic_endpoints_data_from_dl(db_path):
         l.endpoint,
         e.endpoint_url,
         s.licence,
-        l.status,
-        l.exception,
+        l.status as latest_status,
+        l.exception as latest_exception,
         l.resource,
 
         max(l.entry_date) as latest_log_entry_date,
@@ -68,9 +68,9 @@ def fetch_latest_endpoints_data_from_dl(db_path):
                 l.endpoint,
                 e.endpoint_url,
                 s.licence,
-                l.status,
+                l.status as latest_status,
                 t2.days_since_200,
-                l.exception,
+                l.exception as latest_exception,
                 l.resource,
 
                 max(l.entry_date) as latest_log_entry_date,
@@ -129,8 +129,8 @@ def create_reporting_tables(historic_endpoints_data, latest_endpoint_data, perfo
             endpoint TEXT,
             endpoint_url TEXT,
             licence TEXT,
-            status TEXT,
-            exception TEXT,
+            latest_status TEXT,
+            latest_exception TEXT,
             resource TEXT,
             latest_log_entry_date TEXT,
             endpoint_entry_date TEXT,
@@ -141,7 +141,7 @@ def create_reporting_tables(historic_endpoints_data, latest_endpoint_data, perfo
     """)
     cursor.executemany("""
             INSERT INTO reporting_historic_endpoints (
-                organisation, name, collection, pipeline, endpoint, endpoint_url, licence, status, exception, resource, 
+                organisation, name, collection, pipeline, endpoint, endpoint_url, licence, latest_status, latest_exception, resource, 
                 latest_log_entry_date, endpoint_entry_date, endpoint_end_date, resource_start_date, resource_end_date
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, historic_endpoints_data)
@@ -156,9 +156,9 @@ def create_reporting_tables(historic_endpoints_data, latest_endpoint_data, perfo
             endpoint TEXT,
             endpoint_url TEXT,
             licence TEXT,
-            status TEXT,
+            latest_status TEXT,
             days_since_200 INTEGER,
-            exception TEXT,
+            latest_exception TEXT,
             resource TEXT,
             latest_log_entry_date TEXT,
             endpoint_entry_date TEXT,
@@ -172,7 +172,7 @@ def create_reporting_tables(historic_endpoints_data, latest_endpoint_data, perfo
     # Insert data into reporting_latest_endpoints
     cursor.executemany("""
             INSERT INTO reporting_latest_endpoints (
-                organisation, name, collection, pipeline, endpoint, endpoint_url, licence, status, days_since_200, exception, resource, 
+                organisation, name, collection, pipeline, endpoint, endpoint_url, licence, latest_status, days_since_200, latest_exception, resource, 
                 latest_log_entry_date, endpoint_entry_date, endpoint_end_date, resource_start_date, resource_end_date, rn
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, latest_endpoint_data)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Removes the endpoint end date column from the resource_summary and issue_type summary tables.
- Renames the status and exception columns as latest_status and latest_exception
- Removes times from date columns

## Related Tickets & Documents

https://trello.com/c/NJSZQBUZ/3512-perf-db-general-changes
