### PR TITLE
Filter old resources

### DIFF
--- a/bin/resources.py
+++ b/bin/resources.py
@@ -27,22 +27,36 @@ for row in csv.DictReader(open("collection/source.csv", newline="")):
                 endpoints[endpoint]["pipelines"][pipeline] = True
                 endpoints[endpoint]["collection"] = row["collection"]
 
+old_resources_map = {}
+
+# Load old-resource.csv to create a mapping of old to updated resources
+for row in csv.DictReader(open("collection/old-resource.csv", newline="")):
+    old_resource = row["old-resource"]
+    updated_resource = row["resource"]
+    old_resources_map[old_resource] = updated_resource
+
 # load resources
 for row in csv.DictReader(open("collection/resource.csv", newline="")):
     resource = row["resource"]
+
+    # Skip this resource if it's an old resource
+    if resource in old_resources_map:
+        continue
     resources[resource] = row
     resources[resource].setdefault("pipelines", {})
     resources[resource]["endpoints"] = row["endpoints"].split(";")
 
     # add collections to the resource
     for endpoint in resources[resource]["endpoints"]:
-        endpoints[endpoint].setdefault("resource", {})
-        endpoints[endpoint][resource] = True
-        resources[resource]["collection"] = endpoints[endpoint]["collection"]
+        if endpoint in endpoints:
+            endpoints[endpoint].setdefault("resource", {})
+            endpoints[endpoint][resource] = True
+            resources[resource]["collection"] = endpoints[endpoint]["collection"]
 
-        # add pipelines to resource
-        for pipeline in endpoints[endpoint]["pipelines"]:
-            resources[resource]["pipelines"][pipeline] = True
+            # add pipelines to resource
+            for pipeline in endpoints[endpoint]["pipelines"]:
+                resources[resource]["pipelines"][pipeline] = True
+
 
 # https://digital-land-production-collection-dataset.s3.eu-west-2.amazonaws.com/{COLLECTION}-collection/issue/{PIPELINE}/{RESOURCE}.csv
 for resource in resources:

--- a/bin/resources.py
+++ b/bin/resources.py
@@ -27,8 +27,8 @@ for row in csv.DictReader(open("collection/source.csv", newline="")):
                 endpoints[endpoint]["pipelines"][pipeline] = True
                 endpoints[endpoint]["collection"] = row["collection"]
 
-old_resources_map = {}
 
+old_resources_map = {}
 # Load old-resource.csv to create a mapping of old to updated resources
 for row in csv.DictReader(open("collection/old-resource.csv", newline="")):
     old_resource = row["old-resource"]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Swati found this issue where the count of issues in individual collection and in concatenated digital-land issues table are different. e.g. the count of "unknow entity" issues in issue table in conservation area is [1200](https://datasette.planning.data.gov.uk/conservation-area?sql=select%0D%0A++count%28rowid%29%2C%0D%0A++issue_type%0D%0A++--%2Cresource%0D%0Afrom%0D%0A++issue%0D%0Awhere%0D%0A++%22issue_type%22+%3D+%3Ap0%0D%0A++group+by%0D%0A++issue_type%0D%0A++--%2Cresource%0D%0A&p0=unknown+entity) but [2175](https://datasette.planning.data.gov.uk/digital-land?sql=select%0D%0A++issue_type%2C%0D%0A++count%28line_number%29%0D%0A++--%2Cresource%0D%0Afrom%0D%0A++issue%0D%0Awhere%0D%0A++%22dataset%22+%3D+%3Ap0%0D%0A++and+%22issue_type%22+%3D+%3Ap1%0D%0A++group+by+%0D%0A++issue_type%0D%0A++--%2Cresource&p0=conservation-area&p1=unknown+entity) in digital land issue table for conservation area dataset

We were not considering the old-resource in digital-land builder when creating the issues list. I have now included it in the code.

## Related Tickets & Documents

- Ticket Link: https://trello.com/c/DgqfOJz2/3586-bug-issue-count-difference-between-digital-land-builder-and-collections
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

need to push it on dev envt and test

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: No tests for digital-land-builder
- [ ] I need help with writing tests

