### PR TITLE
Correcting endpoint count inaccuracies

### DIFF
--- a/makerules/makerules.mk
+++ b/makerules/makerules.mk
@@ -172,8 +172,8 @@ commit-collection::
 state.json::
 	digital-land save-state --specification-dir=specification --collection-dir=$(COLLECTION_DIR) --pipeline-dir=$(PIPELINE_DIR) --output-path=state.json
 
-save-state::
+save-state:: state.json
 	aws s3 cp state.json s3://$(COLLECTION_DATASET_BUCKET_NAME)/state.json --no-progress
 
-load-state:: state.json
+load-state::
 	aws s3 cp s3://$(COLLECTION_DATASET_BUCKET_NAME)/state.json state.json --no-progress || echo state.json not found in s3 bucket $(COLLECTION_DATASET_BUCKET_NAME)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR addresses inaccuracies in the endpoint counts in the provision table, where duplicate rows and a historical errored endpoint were causing misleading active and errored counts. Changed the filtering condition for correct calculation of count.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link: https://github.com/orgs/digital-land/projects/9/views/5?pane=issue&itemId=85539064&issue=digital-land%7Ctechnical-documentation%7C141

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: query change only
- [ ] I need help with writing tests
